### PR TITLE
Added ACCORD_f34.yml, and support for datemode=5 and varname: 'Variab…

### DIFF
--- a/ACCORD_f34.yml
+++ b/ACCORD_f34.yml
@@ -1,0 +1,18 @@
+---
+separator: ';'
+enumname:  'CODE_MEANING'
+typename: 'Type'
+varname: 'Variable'
+description: 'Label'
+patientid: 'MaskID' #patientid
+basedate: '1/1/2000'
+dateformat: 3 # visitdateformat
+datemode: 5
+timevar:
+    default: 'visit'
+datevar: 'visit' #diffdatevarname
+additionaldatediffvarname: 'NA'
+additionaldatedifftimeunits: '0'
+pathroot: 'dbGaP/ACCORD/f34' #pathrootname
+filebase: 'accord_f34_followup'
+...

--- a/ACCORD_key.yml
+++ b/ACCORD_key.yml
@@ -3,6 +3,7 @@ separator: ','
 enumname:  'Label'
 typename: 'Type'
 varname: 'Variable'
+description: ''
 patientid: 'MaskID' 
 basedate: '1/1/2000'
 dateformat: 0 # visitdateformat
@@ -14,5 +15,5 @@ datevar: '' #diffdatevarname
 additionaldatediffvarname: 'NA'
 additionaldatedifftimeunits: '0'
 pathroot: 'dbGaP/ACCORD/Key' #pathrootname
-filebase: 'accord_key2'
+filebase: 'accord_key'
 ...

--- a/AREDS_adverse.yml
+++ b/AREDS_adverse.yml
@@ -3,6 +3,7 @@ separator: ';'
 enumname:  'CODE_MEANING'
 typename: 'TYPE'
 varname: 'VARNAME'
+description: ''
 patientid: 'ID2' #patientid
 basedate: '1/1/2000'
 dateformat: 4 # visitdateformat


### PR DESCRIPTION
Added ACCORD_f34.yml, and support for datemode=5 and varname: 'Variable' to etl.py. The "description" of a variable should be captured in the ontology tree. Currently variable names are too cryptic to be useful when querying.