### PR TITLE
Check that timediff value is not "" line 318

### DIFF
--- a/etl.py
+++ b/etl.py
@@ -315,7 +315,10 @@ class ETLdbGap:
             startdates = []
             for tv in self.config["timevar"]:
                 tvre = self.config["timevar"][tv]
-                timediff = float(self._data[i][self._variables[tv]])
+                if self._data[i][self._variables[tv]] == "":
+                    timediff = 0
+                else:
+                    timediff = float(self._data[i][self._variables[tv]])
                 startdate = self.add_time(visitdateformat, beginDate, timediff)
                 if re.search(tvre, self._data[0][j]):
                     return startdate.strftime("%Y-%m-%d")


### PR DESCRIPTION
*   python etl.py -c AREDS_fundus.yml -i areds_fundus.csv -d dbGaP_Data_Dictionary_AREDS_fundus_x.csv
     *   Result: Error: ID2: 1119 for visno 16: has no value for REPHTIME
     *   Solution: Fix etl.py code to convert “” to 0